### PR TITLE
Fix up GSSAPI auth on macOS

### DIFF
--- a/Unix/buildtool
+++ b/Unix/buildtool
@@ -87,7 +87,7 @@ opts=$*
 
 ##==============================================================================
 ##
-## Extract the --target=TARGET option up front (leave other options in 
+## Extract the --target=TARGET option up front (leave other options in
 ## localopts).
 ##
 ##==============================================================================
@@ -139,13 +139,13 @@ COMMANDS:
         Print architecture ID for this platform.
     compiler
         Print compiler ID for this platform.
-    cc                  
+    cc
         Print command name of C compiler.
-    cxx                 
+    cxx
         Print command name of C++ compiler.
     ar
         Print command name of archive command.
-    size 
+    size
         Print command name of size command.
     cflags [--debug --pic --errwarn --pal]
         Print C compiler flags.
@@ -312,7 +312,7 @@ case "$platform" in
         compiler_revision=`echo $compiler_version | awk -F'.' '{ print $3}'`
         ;;
     SUNOS_I86PC_SUNPRO|SUNOS_SPARC_SUNPRO)
-        compiler_version=`cc -V 2>&1  |  awk -F":" '{ print $2 }'  |  sed "s/.*${command} \([^ ]*\).*$/\1/"` 
+        compiler_version=`cc -V 2>&1  |  awk -F":" '{ print $2 }'  |  sed "s/.*${command} \([^ ]*\).*$/\1/"`
         compiler_major_version=`echo $compiler_version | awk -F'/' '{ print $1}'`
         compiler_minor_version=`echo $compiler_version | awk -F'/' '{ print $2}'`
         compiler_revision=`echo $compiler_version | awk -F'/' '{ print $3}'`
@@ -400,7 +400,7 @@ if [ "$arg1" = "hostname" ]; then
         exit 1
     fi
 
-    if [ "$os" = "DARWIN" ] ; then 
+    if [ "$os" = "DARWIN" ] ; then
         hostname -s
     else
         hostname
@@ -627,7 +627,7 @@ if [ "$arg1" = "cxx" ]; then
             echo CC
             ;;
         AIX_PPC_IBM)
-            echo xlC_r 
+            echo xlC_r
             ;;
         HPUX_IA64_HP|HPUX_PARISC_HP)
             echo aCC -AA
@@ -781,7 +781,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
         LINUX_IX86_GNU|LINUX_X86_64_GNU|LINUX_PPC_GNU|MONTAVISTA_IX86_GNU|NETBSD_IX86_GNU|LINUX_ARM_GNU)
             if test $cxx_opt ; then
                 r="$r -std=gnu++98"
-            fi    
+            fi
 
             if test -z "$debug_opt"; then
                 if test -n "$size_opt"; then
@@ -846,7 +846,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             ## specify target architecture.
             r="$r -xarch=generic"
 
-            ## hide all library symbols by default.            
+            ## hide all library symbols by default.
             r="$r -xldscope=hidden"
 
             ## Stack overflow checking
@@ -868,7 +868,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
 
             ## suppress this warning message.
             test -n "$c_opt" && r="$r -erroff=E_WHITE_SPACE_IN_DIRECTIVE"
-            
+
             ;;
         AIX_PPC_IBM)
             test -n "$debug_opt" && r="$r -qcheck"
@@ -923,6 +923,7 @@ if [ "$arg1" = "cflags" -o "$arg1" = "cxxflags" ]; then
             r="$r -Wall"
             r="$r -I/usr/local/include"
             r="$r -Dis_macos"
+            r="$r -DHEIMDAL"
             r="$r -fvisibility=hidden"
             r="$r -fstack-protector-all"
             r="$r -DGSS_USE_IOV=1"
@@ -1031,7 +1032,7 @@ if [ "$arg1" = "cshlibflags" -o "$arg1" = "cxxshlibflags" ]; then
             r="$r -mt"
             r="$r +Z -Dhpux"
             r="$r +W4232"
-            r="$r +W4275" 
+            r="$r +W4275"
             r="$r -D_XOPEN_SOURCE=600"
             r="$r -D__STDC_EXT__"
             r="$r -lc"
@@ -1141,7 +1142,7 @@ if [ "$arg1" = "cprogflags" -o "$arg1" = "cxxprogflags" ]; then
             r="$r -mt"
             r="$r +Z -Dhpux"
             r="$r +W4232"
-            r="$r +W4275" 
+            r="$r +W4275"
             r="$r -D_XOPEN_SOURCE=600"
             r="$r -D__STDC_EXT__"
             r="$r -lrt"
@@ -1752,7 +1753,7 @@ fi
 
 ##==============================================================================
 ##
-## 'faultinjection' command 
+## 'faultinjection' command
 ##     Whether fault injection is supported (1) or not (0)
 ##
 ##==============================================================================
@@ -1780,7 +1781,7 @@ fi
 
 ##==============================================================================
 ##
-## 'ntlm' command 
+## 'ntlm' command
 ##     Whether gss negotiated ntlm is supported (1) or not (0)
 ##
 ##==============================================================================
@@ -1798,10 +1799,10 @@ if [ "$arg1" = "ntlm" ]; then
             # supported!
             case "$distro" in
                 *edHat*)
-                    
+
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
-                   
+
                     if [ "$distro_major_version" -gt "7" ] ; then
                        echo "1"
                     elif [ "$distro_major_version" -eq "7" ] ; then
@@ -1813,13 +1814,13 @@ if [ "$arg1" = "ntlm" ]; then
                     else
                        echo "0"
                     fi
-    
+
                     ;;
                 *entOS*)
-                    
+
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
-                   
+
                     if [ "$distro_major_version" -gt "7" ] ; then
                        echo "1"
                     elif [ "$distro_major_version" -eq "7" ] ; then
@@ -1831,11 +1832,11 @@ if [ "$arg1" = "ntlm" ]; then
                     else
                        echo "0"
                     fi
-    
+
                     ;;
-    
+
                 *SUSE*)
-    
+
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
                     if [ "$distro_major_version" -ge "12" ] ; then
@@ -1844,7 +1845,7 @@ if [ "$arg1" = "ntlm" ]; then
                        echo "0"
                     fi
                     ;;
-    
+
                 *ebian*)
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
@@ -1854,7 +1855,7 @@ if [ "$arg1" = "ntlm" ]; then
                        echo "0"
                     fi
                     ;;
-    
+
                 *buntu*)
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
@@ -1882,7 +1883,7 @@ fi
 
 ##==============================================================================
 ##
-## 'gssapi_ext' command 
+## 'gssapi_ext' command
 ##     Whether gss negotiated gssapi_ext is supported (1) or not (0)
 ##
 ##==============================================================================
@@ -1900,32 +1901,32 @@ if [ "$arg1" = "gssapi_ext" ]; then
             # supported!
             case "$distro" in
                 *edHat*)
-                    
+
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
-                   
+
                     if [ "$distro_major_version" -gt "5" ] ; then
                        echo "1"
                     else
                        echo "0"
                     fi
-    
+
                     ;;
                 *entOS*)
-                    
+
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
-                   
+
                     if [ "$distro_major_version" -gt "5" ] ; then
                        echo "1"
                     else
                        echo "0"
                     fi
-    
+
                     ;;
-    
+
                 *SUSE*)
-    
+
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
                     if [ "$distro_major_version" -ge "13" ] ; then
@@ -1934,7 +1935,7 @@ if [ "$arg1" = "gssapi_ext" ]; then
                        echo "0"
                     fi
                     ;;
-    
+
                 *ebian*)
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
@@ -1944,7 +1945,7 @@ if [ "$arg1" = "gssapi_ext" ]; then
                        echo "0"
                     fi
                     ;;
-    
+
                 *buntu*)
                     distro_major_version=`echo $distro_version | awk -F'.' '{ print $1}'`
                     distro_minor_version=`echo $distro_version | awk -F'.' '{ print $2}'`
@@ -1983,7 +1984,7 @@ fi
 
 ##==============================================================================
 ##
-## 'vsnprintf' command 
+## 'vsnprintf' command
 ##     Whether vsnprintf return -1 on NULL buffer or not
 ##
 ##==============================================================================


### PR DESCRIPTION
The current code has a few problems when running on macOS

* The `HEIMDAL` macro was not set on macOS, this causes it to try and load the wrong names.
* `GSS_C_NT_HOSTBASED_SERVICE` is not used anywhere in the code (although it probably should be)
    * Planning on revisiting this in another PR as this is the recommended name type for the target name
    * In any case the name is invalid on macOS' Heimdal implementation so just removing it was easier for now
* `GSS_KRB5_NT_PRINCIPAL_NAME` is valid for MIT krb5 but on Heimdal it needs to be accessed with `__gss_krb5_nt_principal_name_oid_desc`

Finally there was an issue when using an IP that was not routable. The `getaddrinfo()` function would set a `NULL` value for `ai_canonname`. This causes a seg fault when calling `strlen(info->ai_canonname)`. Instead this just falls back to using the HTTP hostname that was set and let it fail later on.

Ultimately this enables Kerberos auth to work on macOS.

Unfortunately enabling NTLM auth through SPNEGO requires a lot more effort that I still need to investigate. Right now the code sends the NTLM negotiate and processes the challenge message but it fails to send the authenticate message causing a failure. Hopefully it's a simple fix I can address in another PR.