### PR TITLE
Added HTTPS Certificate Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ It documents the changes in each of the tagged releases
 
 + Added support for channel binding tokens to work with `Auth/CbtHardeningLevel = Strict`
 + Improved error messages displayed when dealing with OpenSSL errors
++ Turned on HTTPS certificate validation by default ignoring whatever is set from PowerShell
+  + You still need to specify `-SessionOption (New-PSSessionOption -SkipCACheck -SkipCNCheck)` when creating the session in PowerShell
+  + These session options are ignored in this OMI library, to disable cert verification here, set the env vars `OMI_SKIP_CA_CHECK=1` and `OMI_SKIP_CN_CHECK=1`
+  + A future version may respect the `-SessionOption` skip checks in the future but until that data is actually sent to the library we opt for a safer default by always checking unless our env vars are set
 
 ## 1.1.0 - 2020-09-01
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ The following changes have been made:
 + Turned on HTTPS certificate verification by default
   + Any HTTPS connections will have OpenSSL check the server's certificate like a proper HTTPS connection
   + You still need to tell PowerShell to skip the checks but those skip options are ignored in OMI
-  + To truly skip cert verification, set the env vars `OMI_SKIP_CA_CHECK=1` and `OMI_SKIP_CN_CHECK=1`
-  + TODO: Document revocation checks and why they aren't implemented
+  + See [https_validation](docs/https_validation.md) for more details on this topic
 
 I am not looking at fixing any underlying problems in this library or work on the server side part of OMI.
 This is purely focusing on improving the experience when using WinRM as a client on non-Windows based hosts within PowerShell.
@@ -111,8 +110,7 @@ A few thing to note when using the WSMan transport in PowerShell
 + If you want to use Negotiate/Kerberos auth you must also supply `-Authentication Negotiate` or `-Authentication Kerberos` to the cmdlet that uses WSMan
 + When using Basic auth you MUST connect over HTTPS and skip cert verification by adding `-SessionOption (New-PSSession -SkipCACheck -SkipCNCheck)`
   + While this tells PowerShell to skip the certificate checks, this library will still continue to do so
-  + This is due to PowerShell having a hardcoded check for these session options but not actually passing it down to the OMI library
-  + I've opted to make HTTPS secure by default and to actually skip the certificate verification set the env vars `OMI_SKIP_CA_CHECK=1` and `OMI_SKIP_CN_CHECK=1`
+  + See [https_validation](docs/https_validation.md) for more details on this topic
 
 ## Testing
 
@@ -264,11 +262,8 @@ Can't fix issues are either issues that would take a lot of effort to implement 
   + Really why would you want to do this anyway
 + The session options `-SessionOption (New-PSSession -SkipCACheck -SkipCNCheck)` are ignored and OMI will always verify the HTTPS certificate
   + PowerShell hardcodes a check that forces you to do `-UseSSL -SessionOption (New-PSSession -SkipCACheck -SkipCNCheck)`
-  + This is because the upstream OMI library never did any certificate validation and PowerShell wanted you to be aware of that
   + Since the `1.2.0` release of this fork, cert validation is set to always occur regardless of the session options from PowerShell
-  + To disable certificate verification set the env vars `OMI_SKIP_CA_CHECK=1` and `OMI_SKIP_CN_CHECK=1`
-  + You cannot set this for a specific connection, it's either always verify (default) or not (env vars set to `1`)
-  + A future version of this fork may start to respect the `-SessionOption` values from PowerShell but until they are actually plumbed in and become optional they will be ignored
+  + See [https_validation](docs/https_validation.md) for more details on this topic
 + Cannot add CredSSP authentication
   + Could technically implement the auth code in this library but that won't be easy
   + Cannot bypass the hardcoded check in PowerShell that causes a failure when `-Authentication CredSSP`

--- a/Unix/http/httpclient.c
+++ b/Unix/http/httpclient.c
@@ -184,7 +184,9 @@ static const char* sslstrerror(unsigned long SslError)
 // JBOREAN CHANGE: Constants used for certificate validation
 static const char* SKIP_CA_CHECK = "OMI_SKIP_CA_CHECK";
 static const char* SKIP_CN_CHECK = "OMI_SKIP_CN_CHECK";
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 static const unsigned long HOST_VERIFICATION_FLAGS = X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
+#endif
 
 /*
     NOTE: Initialize the session map
@@ -3360,6 +3362,7 @@ MI_Result HttpClient_StartRequestV2(
             goto Error;
         }
 
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
         // If OMI_SKIP_CA_CHECK was set but not OMI_SKIP_CN_CHECK we need to manually verify the hostname here.
         if (skipCACheck && !skipCNCheck)
         {
@@ -3375,6 +3378,7 @@ MI_Result HttpClient_StartRequestV2(
                 goto Error;
             }
         }
+#endif
 
 #if AUTHORIZATION
         // Getting the CBT data shouldn't warrant a failure so we just ignore a failure for now.

--- a/Unix/http/httpclient.c
+++ b/Unix/http/httpclient.c
@@ -181,6 +181,11 @@ static const char* sslstrerror(unsigned long SslError)
 #endif
 #endif
 
+// JBOREAN CHANGE: Constants used for certificate validation
+static const char* SKIP_CA_CHECK = "OMI_SKIP_CA_CHECK";
+static const char* SKIP_CN_CHECK = "OMI_SKIP_CN_CHECK";
+static const unsigned long HOST_VERIFICATION_FLAGS = X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS;
+
 /*
     NOTE: Initialize the session map
 */
@@ -1735,8 +1740,8 @@ static MI_Result _CreateSSLContext(
     SSL_CTX *sslContext;
     // JBOREAN CHANGE: Use an env var to allow a user to specify that TLS certs must be verified.
     char* sslErrorString = NULL;
-    MI_Boolean skipCACheck = _GetEnvVarBool("OMI_SKIP_CA_CHECK");
-    MI_Boolean skipCNCheck = _GetEnvVarBool("OMI_SKIP_CN_CHECK");
+    MI_Boolean skipCACheck = _GetEnvVarBool(SKIP_CA_CHECK);
+    MI_Boolean skipCNCheck = _GetEnvVarBool(SKIP_CN_CHECK);
     const char* hostnameToVerify = host;
 
     if (CreateSSLContext(&sslContext, sslOptions) != MI_RESULT_OK)
@@ -1755,7 +1760,7 @@ static MI_Result _CreateSSLContext(
             trace_SSL_BadTrustDir(trustedCertsDir);
         }
         // JBOREAN CHANGE: Instead of only trusting if a custom trust cert dir is set we always trust unless opted out
-        // by the env vars OMI_SKIP_CA_CHECK and OMI_SKIP_CN_CHECK
+        // by the env vars OMI_SKIP_CA_CHECK and OMI_SKIP_CN_CHECK further below.
         // SSL_CTX_set_verify(sslContext, SSL_VERIFY_PEER, _ctxVerify);
     }
     else
@@ -1775,12 +1780,13 @@ static MI_Result _CreateSSLContext(
     // Hostname verification was only added in OpenSSL 1.0.2 or newer. Debian 8 is the only host that still runs with
     // an older version so we just need to make sure we document that.
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
-    if (skipCNCheck)  // If end user doesn't want to check the CN, pass in a NULL hostname to the SSL_CTX.
+    // If end user doesn't want to check the CN, pass in a NULL hostname to the SSL_CTX host param.
+    if (skipCNCheck)
         hostnameToVerify = NULL;
 
     X509_VERIFY_PARAM* param = SSL_CTX_get0_param(sslContext);
-    X509_VERIFY_PARAM_set_hostflags(param, 0x4);  //0x4 X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
-    if (!X509_VERIFY_PARAM_set1_host(param, host, 0))
+    X509_VERIFY_PARAM_set_hostflags(param, HOST_VERIFICATION_FLAGS);
+    if (!X509_VERIFY_PARAM_set1_host(param, hostnameToVerify, 0))
     {
         sslErrorString = ERR_error_string(ERR_get_error(), NULL);
         LOGE2((ZT("_CreateSSLContext - Failed to set hostname verification (%s)"), sslErrorString));
@@ -1790,7 +1796,11 @@ static MI_Result _CreateSSLContext(
     }
 #endif
 
-    if (!(skipCACheck && skipCNCheck))
+    // While not setting SSL_CTX_set_verify() will also disable the hostname check. If only OMI_SKIP_CA_CHECK is set
+    // and OMI_SKIP_CN_CHECK is not, then the hostname will be manually verified after the SSL_connect is done. I
+    // don't know of a way to disable the CA check but still get OpenSSL to verify it. In reality skipping the CA
+    // check breaks the trust of checking the cert anyway so it's mostly a useless option.
+    if (!skipCACheck)
     {
         SSL_CTX_set_verify(sslContext, SSL_VERIFY_PEER, _ctxVerify);
     }
@@ -1889,10 +1899,10 @@ static MI_Result _CreateSocketAndConnect(
 // JBOREAN CHANGE: Used by _CreateConnectorSocket to create the channel binding token data for GSSAPI.
 #if AUTHORIZATION
 static MI_Result _CreateChannelBindingToken(
-    HttpClient_SR_SocketData* handler)
+    HttpClient_SR_SocketData* handler,
+    X509* certificate)
 {
     MI_Result res = MI_RESULT_OK;
-    X509* certificate = NULL;
     int algoNID;
     const EVP_MD* algoType = NULL;
     unsigned char* certHash = NULL;
@@ -1902,15 +1912,6 @@ static MI_Result _CreateChannelBindingToken(
     int bindingPrefixLength = strlen(bindingPrefix);
     int bindingStructLength = sizeof(struct gss_channel_bindings_struct);
     gss_channel_bindings_t bindings = NULL;
-
-    // TODO: OpenSSL 3.0.0 has deprecated SSL_get_peer_certificate in favour of SSL_get1_peer_certificate.
-    certificate = SSL_get_peer_certificate(handler->ssl);
-    if (!certificate)
-    {
-        LOGE2((ZT("_CreateChannelBindingToken - Failed to get TLS peer certificate - skipping CBT")));
-        res = MI_RESULT_FAILED;
-        goto Done;
-    }
 
     if (!OBJ_find_sigid_algs(X509_get_signature_nid(certificate), &algoNID, NULL))
     {
@@ -1969,11 +1970,6 @@ static MI_Result _CreateChannelBindingToken(
     LOGD2((ZT("_CreateChannelBindingToken - OK exit")));
 
 Done:
-    if (certificate)
-    {
-        X509_free(certificate);
-    }
-
     if (certHash)
     {
         PAL_Free(certHash);
@@ -3329,13 +3325,19 @@ MI_Result HttpClient_StartRequestV2(
 
     // JBOREAN CHANGE: Make sure the SSL context has been connected so we can get the peer certificate for GSSAPI TLS
     // channel binding token support. This must be done before the authentication header is build.
+    X509* certificate = NULL;
+    int sslError = 0;
+    char* sslErrorString = NULL;
+    MI_Boolean skipCACheck = _GetEnvVarBool(SKIP_CA_CHECK);
+    MI_Boolean skipCNCheck = _GetEnvVarBool(SKIP_CN_CHECK);
+
     if (client->connector->ssl)
     {
         int res = SSL_connect(client->connector->ssl);
         if (res < 1)
         {
-            int sslError = SSL_get_error(client->connector->ssl, res);
-            char* sslErrorString = ERR_error_string(ERR_get_error(), NULL);
+            sslError = SSL_get_error(client->connector->ssl, res);
+            sslErrorString = ERR_error_string(ERR_get_error(), NULL);
             client->connector->errMsg = (MI_Char*)sslErrorString;
             LOGE2((ZT("HttpClient_StartRequestV2 - SSL connect returned OpenSSL error %d (%s)"), sslError, sslErrorString));
 
@@ -3345,10 +3347,41 @@ MI_Result HttpClient_StartRequestV2(
 
         LOGD2((ZT("HttpClient_StartRequestV2 - SSL connect using socket %d returned result: %d, errno: %d (%s)"), client->connector->base.sock, res, errno, strerror(errno)));
 
+        // TODO: OpenSSL 3.0.0 has deprecated SSL_get_peer_certificate in favour of SSL_get1_peer_certificate.
+        certificate = SSL_get_peer_certificate(client->connector->ssl);
+        if (!certificate)
+        {
+            sslError = SSL_get_error(client->connector->ssl, res);
+            sslErrorString = ERR_error_string(ERR_get_error(), NULL);
+            client->connector->errMsg = (MI_Char*)sslErrorString;
+            LOGE2((ZT("HttpClient_StartRequestV2 - Failed to get TLS peer certificate with OpenSSL error %d (%s)"), sslError, sslErrorString));
+
+            r = MI_RESULT_FAILED;
+            goto Error;
+        }
+
+        // If OMI_SKIP_CA_CHECK was set but not OMI_SKIP_CN_CHECK we need to manually verify the hostname here.
+        if (skipCACheck && !skipCNCheck)
+        {
+            sslError = X509_check_host(certificate, client->connector->hostname, 0, HOST_VERIFICATION_FLAGS, NULL);
+            if (sslError < 1)
+            {
+                const MI_Char* errorMessage = "Certificate hostname verification failed - set OMI_SKIP_CN_CHECK=1 to ignore.";
+                client->connector->errMsg = errorMessage;
+                LOGE2((ZT("HttpClient_StartRequestV2 - %s"), errorMessage));
+                X509_free(certificate);
+
+                r = MI_RESULT_FAILED;
+                goto Error;
+            }
+        }
+
 #if AUTHORIZATION
         // Getting the CBT data shouldn't warrant a failure so we just ignore a failure for now.
-        _CreateChannelBindingToken(client->connector);
+        _CreateChannelBindingToken(client->connector, certificate);
 #endif
+
+        X509_free(certificate);
     }
 
     // Get the session cookie from the last response, if available

--- a/Unix/http/httpcommon.h
+++ b/Unix/http/httpcommon.h
@@ -21,6 +21,8 @@
 #ifdef CONFIG_POSIX
 # include <openssl/ssl.h>
 # include <openssl/err.h>
+// JBOREAN CHANGE: Required for hostname verification
+# include <openssl/x509v3.h>
 #endif
 
 #define ENGINE_TYPE 'E'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,8 @@ stages:
         }
       errorActionPreference: Stop
       displayName: Make sure the output library can be loaded in PowerShell and returns the version.
-      condition: ne(variables['distribution'], 'centos7')  # Bug on Centos7 causes a failure, need to investigate more later
+      # Bug on Centos7 causes a failure, need to investigate more later
+      condition: and(succeeded(), ne(variables['distribution'], 'centos7'))
 
     - task: PublishPipelineArtifact@1
       inputs:

--- a/distribution_meta/archlinux.json
+++ b/distribution_meta/archlinux.json
@@ -15,10 +15,13 @@
     "test_deps": [
         "aur:gss-ntlmssp",
         "aur:powershell-bin",
+        "ca-certificates-utils",
         "docbook-xsl",
         "doxygen",
         "krb5",
         "libwbclient",
         "which"
-    ]
+    ],
+    "cert_staging_dir": "/etc/ca-certificates/trust-source/anchors",
+    "cert_staging_cmd": "update-ca-trust extract"
 }

--- a/distribution_meta/centos7.json
+++ b/distribution_meta/centos7.json
@@ -22,5 +22,7 @@
         "krb5-workstation",
         "powershell",
         "which"
-    ]
+    ],
+    "cert_staging_dir": "/etc/pki/ca-trust/source/anchors",
+    "cert_staging_cmd": "update-ca-trust extract"
 }

--- a/distribution_meta/centos8.json
+++ b/distribution_meta/centos8.json
@@ -22,5 +22,7 @@
         "krb5-workstation",
         "powershell",
         "which"
-    ]
+    ],
+    "cert_staging_dir": "/etc/pki/ca-trust/source/anchors",
+    "cert_staging_cmd": "update-ca-trust extract"
 }

--- a/distribution_meta/debian10.json
+++ b/distribution_meta/debian10.json
@@ -18,5 +18,7 @@
         "krb5-user",
         "libkrb5-dev",
         "powershell"
-    ]
+    ],
+    "cert_staging_dir": "/usr/local/share/ca-certificates",
+    "cert_staging_cmd": "update-ca-certificates"
 }

--- a/distribution_meta/debian10.json
+++ b/distribution_meta/debian10.json
@@ -20,5 +20,6 @@
         "powershell"
     ],
     "cert_staging_dir": "/usr/local/share/ca-certificates",
-    "cert_staging_cmd": "update-ca-certificates"
+    "cert_staging_cmd": "update-ca-certificates",
+    "cert_extension": "crt"
 }

--- a/distribution_meta/debian8.json
+++ b/distribution_meta/debian8.json
@@ -16,5 +16,7 @@
         "krb5-user",
         "libkrb5-dev",
         "powershell"
-    ]
+    ],
+    "cert_staging_dir": "/usr/local/share/ca-certificates",
+    "cert_staging_cmd": "update-ca-certificates"
 }

--- a/distribution_meta/debian8.json
+++ b/distribution_meta/debian8.json
@@ -18,5 +18,6 @@
         "powershell"
     ],
     "cert_staging_dir": "/usr/local/share/ca-certificates",
-    "cert_staging_cmd": "update-ca-certificates"
+    "cert_staging_cmd": "update-ca-certificates",
+    "cert_extension": "crt"
 }

--- a/distribution_meta/debian9.json
+++ b/distribution_meta/debian9.json
@@ -17,5 +17,7 @@
         "krb5-user",
         "libkrb5-dev",
         "powershell"
-    ]
+    ],
+    "cert_staging_dir": "/usr/local/share/ca-certificates",
+    "cert_staging_cmd": "update-ca-certificates"
 }

--- a/distribution_meta/debian9.json
+++ b/distribution_meta/debian9.json
@@ -19,5 +19,6 @@
         "powershell"
     ],
     "cert_staging_dir": "/usr/local/share/ca-certificates",
-    "cert_staging_cmd": "update-ca-certificates"
+    "cert_staging_cmd": "update-ca-certificates",
+    "cert_extension": "crt"
 }

--- a/distribution_meta/fedora31.json
+++ b/distribution_meta/fedora31.json
@@ -22,5 +22,7 @@
         "krb5-workstation",
         "powershell",
         "which"
-    ]
+    ],
+    "cert_staging_dir": "/etc/pki/ca-trust/source/anchors",
+    "cert_staging_cmd": "update-ca-trust extract"
 }

--- a/distribution_meta/fedora32.json
+++ b/distribution_meta/fedora32.json
@@ -22,5 +22,7 @@
         "krb5-workstation",
         "powershell",
         "which"
-    ]
+    ],
+    "cert_staging_dir": "/etc/pki/ca-trust/source/anchors",
+    "cert_staging_cmd": "update-ca-trust extract"
 }

--- a/distribution_meta/macOS.json
+++ b/distribution_meta/macOS.json
@@ -9,5 +9,7 @@
     "test_deps": [
         "openssl",
         "cask:powershell"
-    ]
+    ],
+    "cert_staging_dir": "",
+    "cert_staging_cmd": ""
 }

--- a/distribution_meta/macOS.json
+++ b/distribution_meta/macOS.json
@@ -10,6 +10,6 @@
         "openssl",
         "cask:powershell"
     ],
-    "cert_staging_dir": "",
-    "cert_staging_cmd": ""
+    "cert_staging_dir": "/usr/local/etc/openssl@1.1/certs",
+    "cert_staging_cmd": "/usr/local/opt/openssl@1.1/bin/c_rehash"
 }

--- a/distribution_meta/ubuntu16.04.json
+++ b/distribution_meta/ubuntu16.04.json
@@ -17,5 +17,7 @@
         "krb5-user",
         "libkrb5-dev",
         "powershell"
-    ]
+    ],
+    "cert_staging_dir": "/usr/local/share/ca-certificates",
+    "cert_staging_cmd": "update-ca-certificates"
 }

--- a/distribution_meta/ubuntu16.04.json
+++ b/distribution_meta/ubuntu16.04.json
@@ -19,5 +19,6 @@
         "powershell"
     ],
     "cert_staging_dir": "/usr/local/share/ca-certificates",
-    "cert_staging_cmd": "update-ca-certificates"
+    "cert_staging_cmd": "update-ca-certificates",
+    "cert_extension": "crt"
 }

--- a/distribution_meta/ubuntu18.04.json
+++ b/distribution_meta/ubuntu18.04.json
@@ -18,5 +18,7 @@
         "krb5-user",
         "libkrb5-dev",
         "powershell"
-    ]
+    ],
+    "cert_staging_dir": "/usr/local/share/ca-certificates",
+    "cert_staging_cmd": "update-ca-certificates"
 }

--- a/distribution_meta/ubuntu18.04.json
+++ b/distribution_meta/ubuntu18.04.json
@@ -20,5 +20,6 @@
         "powershell"
     ],
     "cert_staging_dir": "/usr/local/share/ca-certificates",
-    "cert_staging_cmd": "update-ca-certificates"
+    "cert_staging_cmd": "update-ca-certificates",
+    "cert_extension": "crt"
 }

--- a/docs/https_validation.md
+++ b/docs/https_validation.md
@@ -1,0 +1,128 @@
+# HTTPS Certificate Validation
+
+This documented the complicated history and current state of HTTPS certificate validation in OMI
+
+## What is it
+
+One of the key cornerstones of SSL/TLS connections is the ability to trust/authenticate that the server the client is connecting to is who they say they are.
+It does this by checking the following about the X509 certificate presented by the server
+
++ The common name (`CN`) or subject alternate names (`SAN`) match the hostname the client is connecting to
++ The certificate is issued by an authority that the client trusts
+
+There is also a third check which sees if the certificate or the certificate authority who issued it has been revoked.
+This check is not implemented in the OMI codebase so it's out of scope for this document.
+
+## How to Use in PowerShell
+
+When connecting to a HTTPS endpoint in PowerShell on Linux you need use the `-UseSSL` parameters and add the options to skip the certificate validation like so:
+
+```powershell
+$invokeParams = @{
+    ComputerName = 'hostname.domain.com'
+    Authentication = 'Negotiate'
+    UseSSL = $true
+    SessionOption = (New-PSSessionOption -SkipCACheck -SkipCNCheck)
+}
+Invoke-Command @invokeParams
+```
+
+There's a hardcoded check in PowerShell that makes sure you have the `-SkipCACheck` and `-SkipCNCheck` session option when creating a HTTPS endpoint.
+This is because historically the upstream OMI library never did any validation so PowerShell wanted to make sure you were explicitly aware that you are skipping one of the core tenants of a HTTPS connection.
+
+Since the `1.2.0` release of this fork, certificate validation has been implemented and enabled by default.
+The `-SkipCACheck` and `-SkipCNCheck` session options must still be set in PowerShell but they are ignored by OMI (because they are never passed through).
+This means that connecting to a HTTPS endpoint using this library will always validate the server's certificate regardless of the options passed in by PowerShell.
+
+## Disabling Validation
+
+If you truly want to disable certificate validation then you need to set the following environment variables to `1`:
+
+* `OMI_SKIP_CA_CHECK`: Like `-SkipCACheck` it will not validate the cert has been signed and issued by a authority the client trusts
+* `OMI_SKIP_CN_CHECK`: Like `-SkipCNCheck` it will still validate the CA chain of the cert but it will not verify the hostname matches the cert `CN` or `SAN` entries
+
+There is no equivalent for `-SkipRevocationCheck` as there is no revocation checks that occur at this point in time.
+
+Because this behaviour is set by an environment variable, it is globally set for a process and cannot be adjusted for an individual connection.
+
+## Future Changes in PowerShell
+
+The end goal would be to remove the requirement for setting `-SkipCACheck` and `-SkipCNCheck` in PowerShell and actually have those options control the verification behaviour in this OMI library.
+This is not an easy task as the current behaviour in PowerShell is designed to address limitations in the OMI library that it ships.
+Maybe in the future if this fork of OMI gets shipped with PowerShell we can drop the requirement for setting those options and actually have them get passed through to OMI.
+
+For now I'm happy that this fork will validate the certificate by default making a HTTPS connection more secure but still provide a way to opt out using the env vars.
+
+## Trusting a CA Chain
+
+The method for trusting a CA chain for use in OMI is a complicated one.
+It is highly dependent on the distribution being used and what OpenSSL library was linked to the compiled OMI library.
+Validation is handled by OpenSSL exclusively so the logic for determining the list of trusted CAs is dependent on how OpenSSL was configured and installed which can differ across the various distributions.
+If you wish to ignore the default system location and provide your own chain of certificate authorities you can set one of these 2 environment variables:
+
++ `SSL_CERT_DIR`
+  + Directory containing CA certificates in the PEM format
+  + Each file contains one CA certificate to trust
+  + The files are looked up by the CA subject name hash value
+  + The dir *SHOULD* have been prepared with the [c_rehash](https://www.openssl.org/docs/manmaster/man1/c_rehash.html) tool to ensure the files have the correct name
+  + This is useful if you want to manage a collection of CAs to trust as individual files
+  + It is easier to use `SSL_CERT_FILE` if you have your own CA chain that needs to be trusted
++ `SSL_CERT_FILE`:
+  + File containing 1 or more CA certificates in the PEM format
+  + Unlike `SSL_CERT_DIR` this is just a file but it can contain multiple certificates to trust
+  + No need to use a tool to generate the file
+
+More information on these 2 env vars can be found on the OpenSSL [SSL_CTX_load_verify_locations](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html) docs.
+
+_Note: Self signed certificates used on the WinRM endpoint cannot be trusted. It must be issued by a CA and then the CA is added to your trust store for OpenSSL to verify the cert properly._
+
+The alternative is to add your CA to the system store that OpenSSL is configured to read.
+This allows you to reutilise that CA for other applications that also use OpenSSL without requiring that env var to always be set.
+The downside is that the paths differ based on the Linux distribution used.
+
+_Note: Adding a CA chain to the system store means any other application will now trust that authority. Only do this if you are truly ok with that._
+
+### Linux
+
+There are multiple locations that is used to manage certificates on a Linux distribution.
+Each distribution can use different paths and commands to keep things in sync so this is a breakdown of each one.
+
+| Distro | Staging Path | Sync Command | c_rehash Package | System Trust Dir | System Trust File Bundle |
+| ------ | ------------ | -----------  | ---------------- | ---------------- | ------------------------ |
+| Arch | /etc/ca-certificates/trust-source/anchors | update-ca-trust extract | openssl | /etc/ssl/certs | /etc/ssl/certs/ca-certificates.crt |
+| CentOS/RHEL | /etc/pki/ca-trust/source/anchors | update-ca-trust extract | openssl-perl | /etc/pki/tls/certs | /etc/pki/tls/certs/ca-bundle.crt |
+| Fedora | /etc/pki/ca-trust/source/anchors | update-ca-trust extract | openssl-perl | /etc/pki/tls/certs | /etc/pki/tls/certs/ca-bundle.crt |
+| Debian | /usr/local/share/ca-certificates⁰ | update-ca-certificates | openssl | /etc/ssl/certs | /etc/ssl/certs/ca-certificates.crt |
+| Ubuntu | /usr/local/share/ca-certificates⁰ | update-ca-certificates | openssl | /etc/ssl/certs | /etc/ssl/certs/ca-certificates.crt |
+
+⁰ - CA chains in the staging path or trust dir must have the extension `.crt` but they are still `PEM` encoded.
+
+The `Staging Path` is the path to copy your CA chain to.
+The `Sync Command` is the command to run to add any of the certs in the `Staging Path` to the default store.
+The `c_rehash Package` is the name of the package to install for the distribution to install the `c_rehash` utility.
+The `System Trust Dir` and `System Trust File Bundle` is the default value for `SSL_CERT_DIR` and `SSL_CERT_FILE` respectively.
+The shouldn't be adding certs to the `System Trust Dir` or `System Trust File Bundle` manually, using the staging process instead.
+
+When adding a new CA chain to your OS it is recommended to copy it to the `Staging Path` then run the `Sync Command`.
+The `Sync Command` will copy the CA chain in the staging dir to the proper location(s) and it should be trusted by OpenSSL from there onwards.
+If you don't wish to add the CA chain to the system wide trust store you should use the `SSL_CERT_DIR` or `SSL_CERT_FILE` env vars to specify your own managed store.
+
+### macOS
+
+Cert validation on macOS has it's own quirks that set it apart from Linux.
+The OMI library is linked against OpenSSL that is installed from `brew` and not the TLS library that comes builtin to macOS.
+When you install `openssl` with `brew`, the install process will take a copy of the existing system keychain and place it into a directory it itself uses.
+Any libraries that are linked to this OpenSSL install will use that directory and not the system keychain.
+Ultimately this means that it will trust any CAs that were present in the macOS keychain when OpenSSL was installed but if you wish to add any more CAs you need to add it yourself.
+
+The docs for the [openssl@1.1](https://formulae.brew.sh/formula/openssl@1.1#default) formula state to add additional certificates do the following:
+
+```bash
+# Add the PEM files into this directory
+$(brew --prefix)/etc/openssl@1.1/certs
+
+# Make sure c_rehash is run to pre the dir now there are more certs
+$(brew --prefix)/opt/openssl@1.1/bin/c_rehash
+```
+
+I no longer deal with macOS on a regular basis so this information may change at any time in the future.

--- a/docs/https_validation.md
+++ b/docs/https_validation.md
@@ -8,6 +8,8 @@ One of the key cornerstones of SSL/TLS connections is the ability to trust/authe
 It does this by checking the following about the X509 certificate presented by the server
 
 + The common name (`CN`) or subject alternate names (`SAN`) match the hostname the client is connecting to
+  + This is not available on the Debian 8 builds due to it using an older OpenSSL build
+  + The hostname checks were added in OpenSSL 1.0.2, if you are compiling this yourself you will not have this feature if you compile against an older version
 + The certificate is issued by an authority that the client trusts
 
 There is also a third check which sees if the certificate or the certificate authority who issued it has been revoked.

--- a/integration_environment/main.yml
+++ b/integration_environment/main.yml
@@ -9,19 +9,32 @@
   hosts: windows
   gather_facts: no
   vars:
+    # Defines the HTTPS listeners to set up and metadata around the cert that backs it.
+    # The ports used are every 2nd number from the base port, e.g. 29900, 299002, 29904, etc.
+    # The default port (5986) is a self signed certificate that is not trusted at all.
+    #   test: The test name to set as the friendly name prefix of the cert
+    #   algorithm: The public key algorithm to use for the certificate (default: sha256)
+    #   subject: Explicit subject to set for the certificate (default is the FQDN of the DC)
+    #   self_signed: Whether the host is self signed or signed by a common CA (default: no)
+    certificate_base_port: 29900
     certificate_info:
-    - name: sha1
-      port: 29900
-    - name: sha256
-      port: 29902
-    - name: sha256-pss
-      port: 29904
-    - name: sha384
-      port: 29906
-    - name: sha512
-      port: 29908
-    - name: sha512-pss
-      port: 29910
+    - test: cbt-sha1
+      algorithm: sha1
+    - test: cbt-sha256
+      algorithm: sha256
+    - test: cbt-sha256-pss
+      algorithm: sha256-pss
+    - test: cbt-sha384
+      algorithm: sha384
+    - test: cbt-sha512
+      algorithm: sha512
+    - test: cbt-sha512-pss
+      algorithm: sha512-pss
+    - test: verification
+    - test: verification-bad-ca
+      self_signed: yes
+    - test: verification-bad-cn
+      subject: fake-host
   tags:
   - windows
 
@@ -39,12 +52,6 @@
       mode: '700'
     delegate_to: localhost
 
-  - name: create ssl config file
-    template:
-      src: openssl.conf.tmpl
-      dest: '{{ playbook_dir }}/cert_setup/openssl.conf'
-    delegate_to: localhost
-
   - name: generate CA and WinRM certificates
     shell: ./generate_cert.sh {{ (inventory_hostname ~ "." ~ domain_name) | quote }} password
     args:
@@ -59,7 +66,7 @@
 
   - name: import the WinRM certs to the certificate store
     win_certificate_store:
-      path: C:\Windows\TEMP\cert_setup\{{ item.name }}.pfx
+      path: C:\Windows\TEMP\cert_setup\{{ item.test }}.pfx
       key_exportable: no
       key_storage: machine
       password: password
@@ -69,7 +76,7 @@
     register: winrm_cert_info
     with_items: '{{ certificate_info }}'
     loop_control:
-      label: '{{ item.name }}'
+      label: '{{ item.test }}'
 
   # WinRM is frustratingly annoying to create an endpoint over multiple ports without having a separate adapter for
   # each listener so we just create a dummy loopback adapter for each one.
@@ -82,7 +89,7 @@
     register: loopback_adapters
     loop: '{{ range(0, certificate_info | length, 1) | list }}'
     loop_control:
-      label: '{{ certificate_info[item|int].name }}'
+      label: '{{ certificate_info[item|int].test }}'
 
   # The other annoying part is that the WinRM service checks that requests come from the registered address it is
   # meant to listen on. Because it is set to listen on a local loopback address we forward the external port for WinRM
@@ -93,9 +100,10 @@
       $ErrorActionPreference = 'Stop'
       $changed = $false
 
-      $externalPort = {{ certificate_info[item|int].port }}
+      $basePort = {{ certificate_base_port }}
+      $externalPort = $basePort + ({{ item|int }} * 2)
       $listenerPort = $externalPort + 1
-      $desiredName = "test-$externalPort-{{ certificate_info[item|int].name }}"
+      $desiredName = "test_{{ certificate_info[item|int].test }}_$externalPort"
       $thumbprint = '{{ winrm_cert_info.results[item|int].thumbprints[0] }}'
       $adapterName = '{{ loopback_adapters.results[item|int].name }}'
 
@@ -134,7 +142,7 @@
           Where-Object Port -eq $listenerPort
 
       # If the listener already exists but is for a different cert or IP then remove it.
-      if ($listener -and ($listener.Address -ne $address -or $listener.CertificateThumbprint -ne $thumbprint)) {
+      if ($listener -and ($listener.Address -ne ('IP:{0}' -f $address) -or $listener.CertificateThumbprint -ne $thumbprint)) {
           Remove-Item -LiteralPath $listener.PSPath -Force -Recurse
           $listener = $null
           $changed = $true
@@ -168,17 +176,17 @@
 
   - name: make sure the WinRM HTTPS listener ports are open
     win_firewall_rule:
-      name: WinRM HTTPS ({{ item.name }} - {{ item.port }})
-      localport: '{{ item.port }}'
+      name: WinRM HTTPS ({{ certificate_info[item|int].test }}
+      localport: '{{ certificate_base_port + (item|int * 2) }}'
       action: allow
       direction: in
       protocol: tcp
       profiles: domain,private,public
       state: present
       enabled: yes
-    with_items: '{{ certificate_info }}'
+    loop: '{{ range(0, certificate_info | length, 1) | list }}'
     loop_control:
-      label: '{{ item.name }}'
+      label: '{{ certificate_info[item|int].test }} - {{ certificate_base_port + (item|int * 2) }}'
 
   - name: make sure the CBT level is set to Strict
     win_shell: |

--- a/integration_environment/main.yml
+++ b/integration_environment/main.yml
@@ -16,6 +16,7 @@
     #   algorithm: The public key algorithm to use for the certificate (default: sha256)
     #   subject: Explicit subject to set for the certificate (default is the FQDN of the DC)
     #   self_signed: Whether the host is self signed or signed by a common CA (default: no)
+    #   system_ca: Whether to sign it with the common system CA or use the explicit one (default: yes)
     certificate_base_port: 29900
     certificate_info:
     - test: cbt-sha1
@@ -35,6 +36,8 @@
       self_signed: yes
     - test: verification-bad-cn
       subject: fake-host
+    - test: verification-other-ca
+      system_ca: no
   tags:
   - windows
 

--- a/integration_environment/templates/generate_cert.sh.tmpl
+++ b/integration_environment/templates/generate_cert.sh.tmpl
@@ -6,19 +6,35 @@ SUBJECT="${1}"
 PASSWORD="${2}"
 
 generate () {
-    KEY="${1}"
-    ALGORITHM="${2:-}"
+    NAME="${1}"
+    SUBJECT="${2}"
+    KEY="${3}"
+    ALGORITHM="${4}"
+    SELF_SIGNED="${5}"
+    CA_OPTIONS=()
     EXTRA_OPTIONS=()
 
-    if [ -z "${ALGORITHM}" ]; then
-        OUTPUT_PATH="${KEY}"
-
-    else
-        echo "Generating RSASSA-PSS certificate"
-        OUTPUT_PATH="${KEY}-${ALGORITHM}"
+    if [ ! -z "${ALGORITHM}" ]; then
         EXTRA_OPTIONS=("-sigopt" "rsa_padding_mode:${ALGORITHM}")
-
     fi
+
+    if [ "${SELF_SIGNED}" = false ]; then
+        CA_OPTIONS=("-CA" "ca.pem" "-CAkey" "ca.key" "-CAcreateserial")
+    else
+        CA_OPTIONS=("-signkey" "${NAME}.key")
+    fi
+
+    cat > openssl.conf << EOL
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[req]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = DNS:${SUBJECT}
+EOL
 
     echo "Generating ${KEY} signed cert"
     openssl req \
@@ -26,8 +42,8 @@ generate () {
         "-${KEY}" \
         -subj "/CN=${SUBJECT}" \
         -newkey rsa:2048 \
-        -keyout "${OUTPUT_PATH}.key" \
-        -out "${OUTPUT_PATH}.csr" \
+        -keyout "${NAME}.key" \
+        -out "${NAME}.csr" \
         -config openssl.conf \
         -reqexts req \
         -passin pass:"${PASSWORD}" \
@@ -36,25 +52,25 @@ generate () {
 
     openssl x509 \
         -req \
-        -in "${OUTPUT_PATH}.csr" \
+        -in "${NAME}.csr" \
         -"-${KEY}" \
-        -CA ca.pem \
-        -CAkey ca.key \
-        -CAcreateserial \
-        -out "${OUTPUT_PATH}.pem" \
+        -out "${NAME}.pem" \
         -days 365 \
         -extfile openssl.conf \
         -extensions req \
         -passin pass:"${PASSWORD}" \
-        ${EXTRA_OPTIONS[@]}
+        ${EXTRA_OPTIONS[@]} \
+        ${CA_OPTIONS[@]}
 
     openssl pkcs12 \
         -export \
-        -out "${OUTPUT_PATH}.pfx" \
-        -inkey "${OUTPUT_PATH}.key" \
-        -in "${OUTPUT_PATH}.pem" \
+        -out "${NAME}.pfx" \
+        -inkey "${NAME}.key" \
+        -in "${NAME}.pem" \
         -passin pass:"${PASSWORD}" \
         -passout pass:"${PASSWORD}"
+        
+    rm openssl.conf
 }
 
 echo "Generating CA issuer"
@@ -73,11 +89,14 @@ openssl req \
     -passin pass:"${PASSWORD}"
 
 {% for info in certificate_info %}
-{% if '-' in info.name %}
-generate {{ info.name.split('-')[0] }} {{ info.name.split('-')[1] }}
+{% if '-' in info.algorithm | default('sha256') %}
+{% set key = info.algorithm.split('-')[0] %}
+{% set algorithm = info.algorithm.split('-')[1] %}
 {% else %}
-generate {{ info.name }}
+{% set key = info.algorithm | default('sha256') %}
+{% set algorithm = '""' %}
 {% endif %}
+generate {{ info.test }} {{ ('subject' in info) | ternary(info.subject, '"${SUBJECT}"') }} {{ key }} {{ algorithm }} {{ info.self_signed | default(False) | bool | lower }}
 {% endfor %}
 
 touch complete.txt

--- a/integration_environment/templates/generate_cert.sh.tmpl
+++ b/integration_environment/templates/generate_cert.sh.tmpl
@@ -2,7 +2,7 @@
 
 set -o pipefail -eux
 
-SUBJECT="${1}"
+DEFAULT_SUBJECT="${1}"
 PASSWORD="${2}"
 
 generate () {
@@ -11,6 +11,7 @@ generate () {
     KEY="${3}"
     ALGORITHM="${4}"
     SELF_SIGNED="${5}"
+    CA_NAME="${6}"
     CA_OPTIONS=()
     EXTRA_OPTIONS=()
 
@@ -19,7 +20,7 @@ generate () {
     fi
 
     if [ "${SELF_SIGNED}" = false ]; then
-        CA_OPTIONS=("-CA" "ca.pem" "-CAkey" "ca.key" "-CAcreateserial")
+        CA_OPTIONS=("-CA" "${CA_NAME}.pem" "-CAkey" "${CA_NAME}.key" "-CAcreateserial")
     else
         CA_OPTIONS=("-signkey" "${NAME}.key")
     fi
@@ -36,7 +37,7 @@ extendedKeyUsage = serverAuth
 subjectAltName = DNS:${SUBJECT}
 EOL
 
-    echo "Generating ${KEY} signed cert"
+    echo "Generating ${NAME} signed cert"
     openssl req \
         -new \
         "-${KEY}" \
@@ -73,7 +74,7 @@ EOL
     rm openssl.conf
 }
 
-echo "Generating CA issuer"
+echo "Generating system trusted CA issuer"
 openssl genrsa \
     -aes256 \
     -out ca.key \
@@ -88,6 +89,21 @@ openssl req \
     -subj "/CN=OMI Root" \
     -passin pass:"${PASSWORD}"
 
+echo "Generating untrusted CA issuer"
+openssl genrsa \
+    -aes256 \
+    -out ca_explicit.key \
+    -passout pass:"${PASSWORD}"
+
+openssl req \
+    -new \
+    -x509 \
+    -days 365 \
+    -key ca_explicit.key \
+    -out ca_explicit.pem \
+    -subj "/CN=OMI Root Explicit" \
+    -passin pass:"${PASSWORD}"
+
 {% for info in certificate_info %}
 {% if '-' in info.algorithm | default('sha256') %}
 {% set key = info.algorithm.split('-')[0] %}
@@ -96,7 +112,7 @@ openssl req \
 {% set key = info.algorithm | default('sha256') %}
 {% set algorithm = '""' %}
 {% endif %}
-generate {{ info.test }} {{ ('subject' in info) | ternary(info.subject, '"${SUBJECT}"') }} {{ key }} {{ algorithm }} {{ info.self_signed | default(False) | bool | lower }}
+generate {{ info.test }} {{ ('subject' in info) | ternary(info.subject, '"${DEFAULT_SUBJECT}"') }} {{ key }} {{ algorithm }} {{ info.self_signed | default(False) | bool | lower }} {{ (info.system_ca | default(True)) | ternary("ca", "ca_explicit") }}
 {% endfor %}
 
 touch complete.txt

--- a/integration_environment/templates/openssl.conf.tmpl
+++ b/integration_environment/templates/openssl.conf.tmpl
@@ -1,9 +1,0 @@
-distinguished_name = req_distinguished_name
-
-[req_distinguished_name]
-
-[req]
-basicConstraints = CA:FALSE
-keyUsage = digitalSignature,keyEncipherment
-extendedKeyUsage = serverAuth
-subjectAltName = DNS:{{ inventory_hostname }}.{{ domain_name }}

--- a/test.py
+++ b/test.py
@@ -53,9 +53,9 @@ def main():
 
         script_steps.append(('Installing test dependency packages', dep_script))
 
-        ca_trust_script = '''cp integration_environment/cert_setup/ca.pem '%s'
-%s
-''' % (distro_details['cert_staging_dir'], distro_details['cert_staging_cmd'])
+        cert_extension = distro_details['cert_extension'] if distro_details['cert_extension'] else 'pem'
+        ca_trust_script = '''cp integration_environment/cert_setup/ca.pem '%s/ca.%s'
+%s''' % (distro_details['cert_staging_dir'], cert_extension, distro_details['cert_staging_cmd'])
         script_steps.append(('Adding CA chain to system trust store', ca_trust_script))
 
         pwsh_deps = '''cat > /tmp/pwsh-requirements.ps1 << EOL
@@ -70,8 +70,10 @@ pwsh -NoProfile -NoLogo -File /tmp/pwsh-requirements.ps1'''
         script_steps.append(('Installing Pester 5+ and other PowerShell deps', pwsh_deps))
 
 
+    # On macOS we aren't running as root in a container so this step needs sudo.
+    sudo_prefix = 'sudo ' if distribution == 'macOS' else ''
     copy_script = '''PWSHDIR="$( dirname "$( readlink "$( which pwsh )" )" )"
-/bin/cp Unix/build-%s/lib/libmi.* "${PWSHDIR}/"''' % (distribution)
+%s/bin/cp Unix/build-%s/lib/libmi.* "${PWSHDIR}/"''' % (sudo_prefix, distribution)
     script_steps.append(('Copying libmi.so to the PowerShell directory', copy_script))
 
     pester_script = '''cat > /tmp/pwsh-test.ps1 << EOL
@@ -86,8 +88,7 @@ Import-Module -Name Pester -MinimumVersion 5.0
 Invoke-Pester -Configuration \$configuration
 EOL
 
-echo "%s" > /tmp/distro.txt
-''' % distribution
+echo "%s" > /tmp/distro.txt''' % distribution
     script_steps.append(('Creating Pester test script', pester_script))
 
     script_steps.append(('Getting PowerShell version', 'pwsh -Command \$PSVersionTable'))

--- a/test.py
+++ b/test.py
@@ -53,6 +53,11 @@ def main():
 
         script_steps.append(('Installing test dependency packages', dep_script))
 
+        ca_trust_script = '''cp integration_environment/cert_setup/ca.pem '%s'
+%s
+''' % (distro_details['cert_staging_dir'], distro_details['cert_staging_cmd'])
+        script_steps.append(('Adding CA chain to system trust store', ca_trust_script))
+
         pwsh_deps = '''cat > /tmp/pwsh-requirements.ps1 << EOL
 \$ErrorActionPreference = 'Stop'
 \$ProgressPreference = 'SilentlyContinue'

--- a/utils.py
+++ b/utils.py
@@ -201,7 +201,8 @@ def load_distribution_config(distribution):  # type: (str) -> Dict[str, any]
     with open(os.path.join(OMI_REPO, 'distribution_meta', '%s.json' % distribution), mode='rb') as fd:
         distro_details = json.loads(fd.read().decode('utf-8'))
 
-    required_keys = {'package_manager', 'build_deps', 'microsoft_repo', 'test_deps'}
+    required_keys = {'package_manager', 'build_deps', 'microsoft_repo', 'test_deps', 'cert_staging_dir',
+        'cert_staging_cmd'}
     optional_keys = {'container_image'}
     valid_keys = required_keys.union(optional_keys)
     actual_keys = set(distro_details.keys())

--- a/utils.py
+++ b/utils.py
@@ -62,7 +62,7 @@ def build_package_command(package_manager, packages):  # type: (str, List[str]) 
         cask_packages = []
 
         for package in packages:
-            if package.startswith('brew:'):
+            if package.startswith('cask:'):
                 cask_packages.append(package[5:])
 
             else:
@@ -203,7 +203,7 @@ def load_distribution_config(distribution):  # type: (str) -> Dict[str, any]
 
     required_keys = {'package_manager', 'build_deps', 'microsoft_repo', 'test_deps', 'cert_staging_dir',
         'cert_staging_cmd'}
-    optional_keys = {'container_image'}
+    optional_keys = {'container_image', 'cert_extension'}
     valid_keys = required_keys.union(optional_keys)
     actual_keys = set(distro_details.keys())
 


### PR DESCRIPTION
Added code that turns on HTTPS certificate verification by default. Still requires some changes to the integration tests to properly try out but a manual test seems to be fine.

This changes the behaviour where cert validation never occurred before. While technically a breaking change I feel that it's for the best to ensure secure connections are actually done with a trusted host. To disable cert verification set the env vars `OMI_SKIP_CA_CHECK=1` and `OMI_SKIP_CN_CHECK=1`.