### PR TITLE
macOS use OpenSSL 1.1 on Azure Pipelines Build

### DIFF
--- a/build.py
+++ b/build.py
@@ -57,6 +57,21 @@ fi'''.format(output_dirname)
     ]
     if args.debug:
         configure_args.append('--enable-debug')
+
+    # macOS on Azure Pipelines has OpenSSL 1.0.2 installed but we want to compile against the OpenSSL version in our
+    # dep list which is openssl@1.1. Because the deps are installed at runtime we need our build script to find that
+    # value and add to our configure args.
+    if distribution == 'macOS':
+        script_steps.append(('Getting OpenSSL locations for macOS',
+            'OPENSSL_PREFIX="$(brew --prefix openssl@1.1)"'))
+
+        configure_args.extend([
+            '--openssl="${OPENSSL_PREFIX}/bin/openssl"',
+            '--opensslcflags="-I${OPENSSL_PREFIX}/include"',
+            '--openssllibs="-L${OPENSSL_PREFIX}/lib -lssl -lcrypto -lz"',
+            '--openssllibdir="${OPENSSL_PREFIX}/lib"',
+        ])
+
     configure_script = build_multiline_command('./configure', configure_args)
 
     script_steps.append(('Running configure', configure_script))

--- a/distribution_meta/macOS.json
+++ b/distribution_meta/macOS.json
@@ -3,7 +3,7 @@
     "package_manager": "brew",
     "microsoft_repo": "",
     "build_deps": [
-        "openssl",
+        "openssl@1.1",
         "pkg-config"
     ],
     "test_deps": [


### PR DESCRIPTION
The Azure Pipelines macOS agent comes with OpenSSL 1.0.2 https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#utilities. Because the vast majority of real world usage would be using OpenSSL from `brew install openssl` we want to produce a binary that is linked to that version (1.1.x). This change makes sure the build process uses that OpenSSL feature and not the older 1.0.2 version.

Fixes https://github.com/jborean93/omi/issues/9