### PR TITLE
Support getting cert check options from PowerShell SessionOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ It documents the changes in each of the tagged releases
 + Created `PSWSMan` which is a PowerShell module uploaded to the PowerShell Gallery that can install and manage the OMI libraries for you
 + Build `libpsrpclient` as well and add it to the release artifacts
 + Added Alpine 3 to the build matrix
++ Added support for reading `New-PSSessionOption -SkipCACheck -SkipCNCheck` from PowerShell
+  + Requires changes in PowerShell to come through but it sets up the groundwork for those changes to go in
 
 ## 1.2.1 - 2020-09-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ It documents the changes in each of the tagged releases
 + Created `PSWSMan` which is a PowerShell module uploaded to the PowerShell Gallery that can install and manage the OMI libraries for you
 + Build `libpsrpclient` as well and add it to the release artifacts
 + Added Alpine 3 to the build matrix
-+ Added support for reading `New-PSSessionOption -SkipCACheck -SkipCNCheck` from PowerShell
-  + Requires changes in PowerShell to come through but it sets up the groundwork for those changes to go in
++ Added support for reading `New-PSSessionOption -SkipCACheck -SkipCNCheck` from PowerShell instead of relying on the env vars
+  + Requires PowerShell v7.2.0
+  + v7.2.0 and later do not need to have `-SessionOption (New-PSSessionOption -SkipCACheck -SkipCNCheck)` set
+  + Those options can now also control cert verification behaviour per session
+  + Older versions must still set those session options and use the env vars to skip cert verification
 
 ## 1.2.1 - 2020-09-26
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following changes have been made:
   + If the client fails to derive the CBT token, further information can be found in the [logs](#troubleshooting)
 + Turned on HTTPS certificate verification by default
   + Any HTTPS connections will have OpenSSL check the server's certificate like a proper HTTPS connection
-  + You still need to tell PowerShell to skip the checks but those skip options are ignored in OMI
+  + For PowerShell versions older than `7.2`, you still need to tell PowerShell to skip the checks but those skip options are ignored in OMI
   + See [https_validation](docs/https_validation.md) for more details on this topic
 + Also create a slightly customised [libpsrpclient](https://github.com/PowerShell/psl-omi-provider)
   + This enables WSMan on distributions that Microsoft does not include `libpsrpclient` for
@@ -192,10 +192,6 @@ Can't fix issues are either issues that would take a lot of effort to implement 
 + Cannot do basic auth over HTTP
   + PowerShell hardcodes a check that stops you from doing this for security reasons
   + Really why would you want to do this anyway
-+ The session options `-SessionOption (New-PSSession -SkipCACheck -SkipCNCheck)` are ignored and OMI will always verify the HTTPS certificate
-  + PowerShell hardcodes a check that forces you to do `-UseSSL -SessionOption (New-PSSession -SkipCACheck -SkipCNCheck)`
-  + Since the `1.2.0` release of this fork, cert validation is set to always occur regardless of the session options from PowerShell
-  + See [https_validation](docs/https_validation.md) for more details on this topic
 + When using MIT krb5 as the GSSAPI backend, Kerberos delegation will only work when `/etc/krb5.conf` contains `[libdefaults]\nforwardable = true`
   + This is a problem in that library where `gss_acquire_cred_with_pass` will only acquire a forwardable ticket (required for delegation) if the `krb5.conf` contains the `forwardable = true` setting
   + Recent versions of Heimdal are not affected

--- a/Unix/http/httpclient_private.h
+++ b/Unix/http/httpclient_private.h
@@ -42,6 +42,10 @@ typedef struct _HttpClient_SR_SocketData {
     SSL *ssl;
     MI_Boolean reverseOperations;   /*reverse read/write Events/Handlers */
 
+    // JBOREAN CHANGE: Store the cert verification state from the session options
+    MI_Boolean skipCACheck;
+    MI_Boolean skipCNCheck;
+
     // JBOREAN CHANGE: Added support for channel binding tokens has rearranged the connection method and now needs to
     // store the TLS channel bindings token.
     // MI_Boolean connectDone;

--- a/build.py
+++ b/build.py
@@ -40,7 +40,9 @@ def main():
     if args.docker and not distro_details['container_image']:
         raise ValueError("Cannot run --docker on %s as no container_image has been specified" % distribution)
 
-    script_steps = [('Getting current directory path', 'OMI_REPO="$( pwd )"\necho "Current Directory: $OMI_REPO"')]
+    script_steps = [('Getting current directory path', '''OMI_REPO="$( pwd )"
+echo "Current Directory: $OMI_REPO"
+cd Unix''')]
     output_dirname = 'build-%s' % distribution
     library_extension = 'dylib' if distribution == 'macOS' else 'so'
 
@@ -50,8 +52,7 @@ def main():
 
     # Do this in the container as selinux could have these folders be under root
     if not args.skip_clear:
-        rm_script = '''cd Unix
-if [ -d "{0}" ]; then
+        rm_script = '''if [ -d "{0}" ]; then
     echo "Found existing build folder '{0}', clearing"
     rm -rf "{0}"
 else

--- a/libmi.tests.ps1
+++ b/libmi.tests.ps1
@@ -321,7 +321,7 @@ Describe "PSRemoting over HTTPS" {
         @{
             Scenario = 'Skip CA check'
             Process = { Disable-WSManCertVerification -CACheck }
-            Expected = '*Certificate hostname verification failed - set OMI_SKIP_CN_CHECK=1 to ignore.*'
+            Expected = '*Certificate hostname verification failed.*'
         }
     ) {
         .$Process
@@ -363,7 +363,7 @@ Describe "PSRemoting over HTTPS" {
         @{
             Scenario = 'Skip CA check'
             Process = { Disable-WSManCertVerification -CACheck }
-            Expected = '*Certificate hostname verification failed - set OMI_SKIP_CN_CHECK=1 to ignore.*'
+            Expected = '*Certificate hostname verification failed.*'
         },
         @{
             Scenario = 'Skip CN check'

--- a/psl-omi-provider/5.CertificateCheck.diff
+++ b/psl-omi-provider/5.CertificateCheck.diff
@@ -1,14 +1,35 @@
 diff --git a/src/Client.c b/src/Client.c
-index 81480c2..71f6c38 100644
+index 81480c2..f2c06f1 100644
 --- a/src/Client.c
 +++ b/src/Client.c
-@@ -576,6 +576,56 @@ MI_EXPORT MI_Uint32 WINAPI WSManSetSessionOption(
+@@ -46,6 +46,10 @@ void MI_CALL Command_CreateInstance( Command_Self* self, MI_Context* context, co
+ void MI_CALL Command_ModifyInstance( Command_Self* self, MI_Context* context, const MI_Char* nameSpace, const MI_Char* className, const Command* modifiedInstance, const MI_PropertySet* propertySet){}
+ void MI_CALL Command_DeleteInstance( Command_Self* self, MI_Context* context, const MI_Char* nameSpace, const MI_Char* className, const Command* instanceName){}
+ 
++// Need to check if PowerShell will not require the -SkipCACheck and -SkipCNCheck options. We know this is the case if
++// WSManGetSessionOptionAsDword is called for CA/CN check as PowerShell never got those option values before it
++// supported cert validation.
++int PWSH_SUPPORTS_CERT_VALIDATION = 0;
+ 
+ /* Note: Change logging level in omiserver.conf */
+ #define SHELL_LOGGING_FILE "shellclient"
+@@ -576,6 +580,73 @@ MI_EXPORT MI_Uint32 WINAPI WSManSetSessionOption(
              }
              miResult = MI_RESULT_OK;
              break;
 +        case WSMAN_OPTION_SKIP_CA_CHECK:
 +            __LOGD(("WSMAN_OPTION_SKIP_CA_CHECK=%u", data->number));
-+            if (data->type == WSMAN_DATA_TYPE_DWORD)
++
++            // If PWSH_SUPPORTS_CERT_VALIDATION == 0 at this point then pwsh has not checked if validation is done and
++            // thus required the -SkipCACheck and -SkipCNCheck options. We don't want to pass those along to OMI so
++            // cert validation actually happens. If end users want to disable validation then they should use the env
++            // vars instead. This should be removed at some future point.
++            if (PWSH_SUPPORTS_CERT_VALIDATION == 0)
++            {
++                __LOGD(("pwsh enforces cert checks, ignoring option %u", option));
++                miResult = MI_RESULT_OK;
++            }
++            else if (data->type == WSMAN_DATA_TYPE_DWORD)
 +            {
 +                if (data->number)
 +                {
@@ -33,7 +54,14 @@ index 81480c2..71f6c38 100644
 +            break;
 +        case WSMAN_OPTION_SKIP_CN_CHECK:
 +            __LOGD(("WSMAN_OPTION_SKIP_CN_CHECK=%u", data->number));
-+            if (data->type == WSMAN_DATA_TYPE_DWORD)
++
++            // See WSMAN_OPTION_SKIP_CA_CHECK for more details
++            if (PWSH_SUPPORTS_CERT_VALIDATION == 0)
++            {
++                __LOGD(("pwsh enforces cert checks, ignoring option %u", option));
++                miResult = MI_RESULT_OK;
++            }
++            else if (data->type == WSMAN_DATA_TYPE_DWORD)
 +            {
 +                if (data->number)
 +                {
@@ -59,7 +87,7 @@ index 81480c2..71f6c38 100644
          default:
              __LOGD(("ignored option %u", option));
              miResult = MI_RESULT_OK;    /* Assume we can ignore it */
-@@ -592,6 +642,7 @@ MI_EXPORT MI_Uint32 WINAPI WSManGetSessionOptionAsDword(
+@@ -592,6 +663,7 @@ MI_EXPORT MI_Uint32 WINAPI WSManGetSessionOptionAsDword(
      _Inout_ MI_Uint32 *value)
  {
      MI_Uint32 miResult = MI_RESULT_OK;
@@ -67,11 +95,13 @@ index 81480c2..71f6c38 100644
  
      LogFunctionStart("WSManGetSessionOptionAsDword");
      switch (option)
-@@ -606,6 +657,46 @@ MI_EXPORT MI_Uint32 WINAPI WSManGetSessionOptionAsDword(
+@@ -606,6 +678,49 @@ MI_EXPORT MI_Uint32 WINAPI WSManGetSessionOptionAsDword(
              __LOGD(("WSMAN_OPTION_SHELL_MAX_DATA_SIZE_PER_MESSAGE_KB returning 60"));
              break;
  
 +        case WSMAN_OPTION_SKIP_CA_CHECK:
++            // If PowerShell calls this then we know it won't mandate the cert skip checks.
++            PWSH_SUPPORTS_CERT_VALIDATION = 1;
 +            miResult = MI_DestinationOptions_GetCertCACheck(&session->destinationOptions, &check);
 +
 +            // If SetCertCACheck has not been called then the property is not set, treat as the flag is not set.
@@ -92,6 +122,7 @@ index 81480c2..71f6c38 100644
 +            break;
 +
 +        case WSMAN_OPTION_SKIP_CN_CHECK:
++            PWSH_SUPPORTS_CERT_VALIDATION = 1;
 +            miResult = MI_DestinationOptions_GetCertCNCheck(&session->destinationOptions, &check);
 +
 +            // If SetCertCNCheck has not been called then the property is not set, treat as the flag is not set.

--- a/psl-omi-provider/5.CertificateCheck.diff
+++ b/psl-omi-provider/5.CertificateCheck.diff
@@ -1,0 +1,116 @@
+diff --git a/src/Client.c b/src/Client.c
+index 81480c2..71f6c38 100644
+--- a/src/Client.c
++++ b/src/Client.c
+@@ -576,6 +576,56 @@ MI_EXPORT MI_Uint32 WINAPI WSManSetSessionOption(
+             }
+             miResult = MI_RESULT_OK;
+             break;
++        case WSMAN_OPTION_SKIP_CA_CHECK:
++            __LOGD(("WSMAN_OPTION_SKIP_CA_CHECK=%u", data->number));
++            if (data->type == WSMAN_DATA_TYPE_DWORD)
++            {
++                if (data->number)
++                {
++                    if (MI_DestinationOptions_SetCertCACheck(&session->destinationOptions, MI_FALSE) != MI_RESULT_OK)
++                    {
++                        GOTO_ERROR("Failed to turn certificate CA check off", MI_RESULT_SERVER_LIMITS_EXCEEDED);
++                    }
++                }
++                else
++                {
++                    if (MI_DestinationOptions_SetCertCACheck(&session->destinationOptions, MI_TRUE) != MI_RESULT_OK)
++                    {
++                        GOTO_ERROR("Failed to turn certificate CA check on", MI_RESULT_SERVER_LIMITS_EXCEEDED);
++                    }
++                }
++            }
++            else
++            {
++                GOTO_ERROR("Failed to set CA check, invalid parameter", MI_RESULT_INVALID_PARAMETER);
++            }
++            miResult = MI_RESULT_OK;
++            break;
++        case WSMAN_OPTION_SKIP_CN_CHECK:
++            __LOGD(("WSMAN_OPTION_SKIP_CN_CHECK=%u", data->number));
++            if (data->type == WSMAN_DATA_TYPE_DWORD)
++            {
++                if (data->number)
++                {
++                    if (MI_DestinationOptions_SetCertCNCheck(&session->destinationOptions, MI_FALSE) != MI_RESULT_OK)
++                    {
++                        GOTO_ERROR("Failed to turn certificate CN check off", MI_RESULT_SERVER_LIMITS_EXCEEDED);
++                    }
++                }
++                else
++                {
++                    if (MI_DestinationOptions_SetCertCNCheck(&session->destinationOptions, MI_TRUE) != MI_RESULT_OK)
++                    {
++                        GOTO_ERROR("Failed to turn certificate CN check on", MI_RESULT_SERVER_LIMITS_EXCEEDED);
++                    }
++                }
++            }
++            else
++            {
++                GOTO_ERROR("Failed to set CN check, invalid parameter", MI_RESULT_INVALID_PARAMETER);
++            }
++            miResult = MI_RESULT_OK;
++            break;
+         default:
+             __LOGD(("ignored option %u", option));
+             miResult = MI_RESULT_OK;    /* Assume we can ignore it */
+@@ -592,6 +642,7 @@ MI_EXPORT MI_Uint32 WINAPI WSManGetSessionOptionAsDword(
+     _Inout_ MI_Uint32 *value)
+ {
+     MI_Uint32 miResult = MI_RESULT_OK;
++    MI_Boolean check = MI_FALSE;
+ 
+     LogFunctionStart("WSManGetSessionOptionAsDword");
+     switch (option)
+@@ -606,6 +657,46 @@ MI_EXPORT MI_Uint32 WINAPI WSManGetSessionOptionAsDword(
+             __LOGD(("WSMAN_OPTION_SHELL_MAX_DATA_SIZE_PER_MESSAGE_KB returning 60"));
+             break;
+ 
++        case WSMAN_OPTION_SKIP_CA_CHECK:
++            miResult = MI_DestinationOptions_GetCertCACheck(&session->destinationOptions, &check);
++
++            // If SetCertCACheck has not been called then the property is not set, treat as the flag is not set.
++            if (miResult == MI_RESULT_NO_SUCH_PROPERTY)
++            {
++                *value = 0;
++                miResult = MI_RESULT_OK;
++            }
++            else if (miResult == MI_RESULT_OK)
++            {
++                // GetCertCACheck checks if validation is enabled, we want the inverse for this option.
++                if (check)
++                    *value = 0;
++                else
++                    *value = 1;
++                __LOGD(("WSMAN_OPTION_SKIP_CA_CHECK returning %u", value));
++            }
++            break;
++
++        case WSMAN_OPTION_SKIP_CN_CHECK:
++            miResult = MI_DestinationOptions_GetCertCNCheck(&session->destinationOptions, &check);
++
++            // If SetCertCNCheck has not been called then the property is not set, treat as the flag is not set.
++            if (miResult == MI_RESULT_NO_SUCH_PROPERTY)
++            {
++                *value = 0;
++                miResult = MI_RESULT_OK;
++            }
++            else if (miResult == MI_RESULT_OK)
++            {
++                // GetCertCNCheck checks if validation is enabled, we want the inverse for this option.
++                if (check)
++                    *value = 0;
++                else
++                    *value = 1;
++                __LOGD(("WSMAN_OPTION_SKIP_CA_CHECK returning %u", value));
++            }
++            break;
++
+         default:
+             miResult = MI_RESULT_NOT_SUPPORTED;
+             __LOGD(("unknown option %u", option));

--- a/psl-omi-provider/README.md
+++ b/psl-omi-provider/README.md
@@ -10,3 +10,4 @@ Here is a list of patches that are applied during the build and what they are fo
 + [2.AuthenticateDefault.diff](2.AuthenticateDefault.diff) - Sets the default `-Authentication` value to `Negotiate` replicating the behaviour on Windows
 + [3.FixUnitializedVar.diff](3.FixUnitializedVar.diff) - Newer gcc compilers will fail because these vars didn't have a default value and the behaviour is undefined
 + [4.VersionInfo.diff](4.VersionInfo.diff) - Adds `PSRP_Version_Info` as an exported function and relevant build time changes to expose the version defined at build time
++ [5.CertificateCheck.diff](5.CertificateCheck.diff) - Pass along `-SkipCACheck` and `-SkipCNCheck` from PowerShell to support cert verification skips per connection


### PR DESCRIPTION
https://github.com/PowerShell/PowerShell/issues/13577 has more details on the background of this issue but there are 2 issues with cert verification with WSMan endpoints

* PowerShell requires you to set `-SessionOption (New-PSSessionOption -SkipCACheck -SkipCNCheck)`
    * This is because the builtin OMI client did not do any cert verification and they wanted the callers to be aware of this fact
* Since v1.2.0 of this fork, certificate validation was enabled by default regardless of the `-SessionOption` value from PowerShell
    * The only way to opt out of this was through a global env var
    * This env var could not be set per session and required PInvoke to call `setenv` directly due to .NET's handling of env vars on non-Windows hosts

What this PR does is

* Plumb in the logic for handling `WSManSetSessionOption()` for both the CA and CN skip options in `psrpclient`
* Change OMI to use these options, if present, when setting up the verification work
* Expose a way for PowerShell to check if the underlying libs support cert verification without any breaking changes

The first two will allow the `-SkipC*Check` options to pass down and actually work once PowerShell removes the hardcoded check. The last fix gives PowerShell a way to remove that hardcoded check when it knows the client supports certificate verification.

Ultimately this will allow an end user of this fork the ability to connect to a WSMan listener and feel secure that the proper verification work is in place but also allow them to disable those checks using the proper PowerShell way like they can do on Windows.