### PR TITLE
Add ubuntu 20.04 support. Basic clone of ubuntu 18.04.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,6 +36,8 @@ stages:
           distribution: ubuntu16.04
         Ubuntu18.04:
           distribution: ubuntu18.04
+        Ubuntu20.04:
+          distribution: ubuntu20.04
         Archlinux:
           distribution: archlinux
         Alpine3:

--- a/distribution_meta/ubuntu20.04.json
+++ b/distribution_meta/ubuntu20.04.json
@@ -1,0 +1,27 @@
+{
+    "container_image": "ubuntu:20.04",
+    "package_manager": "apt",
+    "microsoft_repo": "https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb",
+    "build_deps": [
+        "cmake",
+        "g++",
+        "git",
+        "libkrb5-dev",
+        "libpam-dev",
+        "libssl-dev",
+        "lsb-release",
+        "make",
+        "openssl",
+        "pkg-config"
+    ],
+    "test_deps": [
+        "gcc",
+        "gss-ntlmssp",
+        "krb5-user",
+        "libkrb5-dev",
+        "powershell"
+    ],
+    "cert_staging_dir": "/usr/local/share/ca-certificates",
+    "cert_staging_cmd": "update-ca-certificates",
+    "cert_extension": "crt"
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -44,6 +44,7 @@ The distributions that are currently setup in the `build.py` script are:
 + [macOS.json](../distribution_meta/macOS.json) - Cannot be built on a Docker container, must be built on an actual macOS host
 + [ubuntu16.04.json](../distribution_meta/ubuntu16.04.json)
 + [ubuntu18.04.json](../distribution_meta/ubuntu18.04.json)
++ [ubuntu20.04.json](../distribution_meta/ubuntu20.04.json)
 
 The json file contains all the information required for `build.py` to install the depedencies and build the libraries.
 


### PR DESCRIPTION
Worked without issue when building in a clean docker container and manually adding to my local powershell dirs. 