### PR TITLE
Slim down the items to compile when building OMI

### DIFF
--- a/Unix/build.mak
+++ b/Unix/build.mak
@@ -51,29 +51,30 @@ endif
 ##
 ##==============================================================================
 
+# JBOREAN CHANGE: Cut down on what is compiled to only what PowerShell needs
 DIRECTORIES =
-DIRECTORIES += chkshlib
-DIRECTORIES += tools
+#DIRECTORIES += chkshlib
+#DIRECTORIES += tools
 
 DIRECTORIES += pal
-DIRECTORIES += pal/nitspal
+#DIRECTORIES += pal/nitspal
 
-DIRECTORIES += nits
+#DIRECTORIES += nits
 
-DIRECTORIES += ut
+#DIRECTORIES += ut
 ifeq ($(COMPILER),GNU)
 DIRECTORIES += strhash
 endif
-DIRECTORIES += mof
+#DIRECTORIES += mof
 DIRECTORIES += sock
 DIRECTORIES += base
-DIRECTORIES += oi/gen_c/common
-DIRECTORIES += oi/gen_c/cmdline
+#DIRECTORIES += oi/gen_c/common
+#DIRECTORIES += oi/gen_c/cmdline
 DIRECTORIES += wql
-DIRECTORIES += gen
-DIRECTORIES += provreg
-DIRECTORIES += provmgr
-DIRECTORIES += disp
+#DIRECTORIES += gen
+#DIRECTORIES += provreg
+#DIRECTORIES += provmgr
+#DIRECTORIES += disp
 DIRECTORIES += omi_error
 DIRECTORIES += miapi
 DIRECTORIES += protocol
@@ -81,29 +82,29 @@ DIRECTORIES += http
 DIRECTORIES += wsman
 DIRECTORIES += xml
 DIRECTORIES += xmlserializer
-DIRECTORIES += omiutils
+#DIRECTORIES += omiutils
 DIRECTORIES += codec/mof
 DIRECTORIES += codec/mof/parser
 DIRECTORIES += midll
-DIRECTORIES += providers
-DIRECTORIES += micxx
-DIRECTORIES += omiclient
-DIRECTORIES += configeditor
-DIRECTORIES += cli
-DIRECTORIES += omireg
-DIRECTORIES += check
-DIRECTORIES += samples
+#DIRECTORIES += providers
+#DIRECTORIES += micxx
+#DIRECTORIES += omiclient
+#DIRECTORIES += configeditor
+#DIRECTORIES += cli
+#DIRECTORIES += omireg
+#DIRECTORIES += check
+#DIRECTORIES += samples
 
-ifndef DISABLE_INDICATION
-DIRECTORIES += indication/common
-DIRECTORIES += indication/indimgr
-endif
+#ifndef DISABLE_INDICATION
+#DIRECTORIES += indication/common
+#DIRECTORIES += indication/indimgr
+#endif
 
-ifdef CONFIG_SINGLEIMAGE
-  DIRECTORIES += image
-else
-  DIRECTORIES += server agent engine
-endif
+#ifdef CONFIG_SINGLEIMAGE
+#  DIRECTORIES += image
+#else
+#  DIRECTORIES += server agent engine
+#endif
 
 ifeq ($(ENABLE_NATIVE_KITS),1)
   DIRECTORIES += installbuilder
@@ -418,3 +419,4 @@ oigenc:
 ##==============================================================================
 
 CACHEGRIND_ARGS = $(BINDIR)/omiserver -i --testopts -l
+

--- a/Unix/midll/GNUmakefile
+++ b/Unix/midll/GNUmakefile
@@ -9,10 +9,13 @@ ifeq ($(OS),DARWIN)
   GENERATE_ORIGIN=1
 endif
 
-ifeq ($(GENERATE_ORIGIN),1)
-	DIRECTORIES = release origin
-else 
-	DIRECTORIES = release
-endif
+# JBOREAN CHANGE: We only need release for PowerShell
+DIRECTORIES = release
+
+#ifeq ($(GENERATE_ORIGIN),1)
+#	DIRECTORIES = release origin
+#else
+#	DIRECTORIES = release
+#endif
 
 include $(ROOT)/mak/rules.mak

--- a/distribution_meta/macOS.json
+++ b/distribution_meta/macOS.json
@@ -3,6 +3,7 @@
     "package_manager": "brew",
     "microsoft_repo": "",
     "build_deps": [
+        "cmake",
         "openssl@1.1",
         "pkg-config"
     ],

--- a/psl-omi-provider/6.NoChkshlibBuild.diff
+++ b/psl-omi-provider/6.NoChkshlibBuild.diff
@@ -1,0 +1,19 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 4cc86d1..05a96ff 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -125,10 +125,11 @@ target_include_directories(psrpclient PRIVATE
+ 	${OMI}/common
+ 	${OPENSSL_INCLUDE_DIRS})
+ 
++# JBOREAN CHANGE: We don't need this for PowerShell
+ # This custom command uses a tool from OMI that tests all library functions 
+ # can be resolved. If it fails it means we are missing a dependent library
+-add_custom_command(TARGET psrpclient POST_BUILD
+-	COMMAND ${OUR_LD_PATH}=${OMI_OUTPUT}/lib && ${OMI_OUTPUT}/bin/chkshlib $<TARGET_FILE:psrpclient>)
++#add_custom_command(TARGET psrpclient POST_BUILD
++#	COMMAND ${OUR_LD_PATH}=${OMI_OUTPUT}/lib && ${OMI_OUTPUT}/bin/chkshlib $<TARGET_FILE:psrpclient>)
+ 
+ 
+ # ##########################################
+

--- a/psl-omi-provider/README.md
+++ b/psl-omi-provider/README.md
@@ -11,3 +11,4 @@ Here is a list of patches that are applied during the build and what they are fo
 + [3.FixUnitializedVar.diff](3.FixUnitializedVar.diff) - Newer gcc compilers will fail because these vars didn't have a default value and the behaviour is undefined
 + [4.VersionInfo.diff](4.VersionInfo.diff) - Adds `PSRP_Version_Info` as an exported function and relevant build time changes to expose the version defined at build time
 + [5.CertificateCheck.diff](5.CertificateCheck.diff) - Pass along `-SkipCACheck` and `-SkipCNCheck` from PowerShell to support cert verification skips per connection
++ [6.NoChkshlibBuild.diff](6.NoChkshlibBuild.diff) - Remove requirement on uneeded OMI binary for the build


### PR DESCRIPTION
There are a lot of components in `omi` that PowerShell does not use and compiling them all takes up uneeded time.